### PR TITLE
Grammar fix

### DIFF
--- a/src/containers/about/about.tsx
+++ b/src/containers/about/about.tsx
@@ -222,7 +222,7 @@ export class About extends React.PureComponent<aboutProps> {
                                             by far my weakest language.
                                             In classical immigrant fashion, the number of words I know is in the dozens,
                                             and I get stumped when two native speakers talk to each other
-                                            and I'm stuck in the middle, mais je parviens.
+                                            and I'm stuck in the middle, mais je me débrouille.
                                         </p>
                                     </li>
                                 </ul>


### PR DESCRIPTION
Moien, moien.
I've been casually stalking you today and while doing so I stumbled upon a grammar mistake on your web page.

Alternatively you could say:

- je m'en sors
- je parviens à me débrouiller